### PR TITLE
Updates to output path, wordlist, m_spider, and README    

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,58 @@ Optional Arguments:
     
     --h   --HELP    Show help message
 
+## Quick Functional Test (using )NetSPI XPath-Injection Lab)
+
+This walk-through spins up NetSPI’s *Path Injection Weakness* demo locally, runs Mellisa against it, and inspects the JSON output.
+
+### 1. Set up the test target  
+
+```bash
+# Clone the lab (or your own fork)
+git clone https://github.com/NetSPI/path-injection-weakness-lab.git
+cd path-injection-weakness-lab
+
+# Start the vulnerable app (using Docker Compose)
+docker compose up -d
+# The lab now listens on http://localhost:8888/
+```
+### 2. Run Mellisa against the lab
+
+```bash
+# From a second terminal in the Mellisa repo root
+source mellisa-venv/bin/activate
+python mellisa.py http://localhost:8888/
+```
+
+Mellisa crawls the target and writes results to:
+```mellisa/output/   # relative to mellisa.py```
+
+### 3. Review Results
+
+Open the JSON file in your editor or run:
+
+```bash
+# files are saved as:  output/<targethost>_<port>.json
+jq . output/localhost_8888.json
+```
+The JSON should look something like this:
+```json
+[
+  {
+    "item_param": [
+      "/css/site.css?v=AKvNjO3dCPPS0eSU1Ez8T2wI280i08yGycV9ndytL-c",
+      "/BookSearchApp.styles.css?v=OCvwvqV0ZzKYOYPf5YqKGSuS_ZPHLCdiAKW156PLJao"
+    ]
+  },
+  {
+    "item_param": [
+      "/css/site.css?v=AKvNjO3dCPPS0eSU1Ez8T2wI280i08yGycV9ndytL-c",
+      "/BookSearchApp.styles.css?v=OCvwvqV0ZzKYOYPf5YqKGSuS_ZPHLCdiAKW156PLJao"
+    ]
+  }
+]
+```
+
 # License 
 
 This project is licensed under the Apache License 2.0 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Mellisa crawls the target and writes results to:
 Open the JSON file in your editor or run:
 
 ```bash
-# files are saved as:  output/<targethost>_<port>.json | <targetdomain>_<directory>_<directory>.json
+# files are saved as:  output/<targethost>_<port>.json | <targetdomain>_<directory>.json
 jq . output/localhost_8888.json
 ```
 The JSON should look something like this:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Mellisa crawls the target and writes results to:
 Open the JSON file in your editor or run:
 
 ```bash
-# files are saved as:  output/<targethost>_<port>.json
+# files are saved as:  output/<targethost>_<port>.json | <targetdomain>_<directory>_<directory>.json
 jq . output/localhost_8888.json
 ```
 The JSON should look something like this:

--- a/mellisa/mellisa.py
+++ b/mellisa/mellisa.py
@@ -25,7 +25,7 @@ def run_spider(output_file=None, **kwargs):
     spider_name = "param_spider"
 
     # directory where mellisa.py is located
-    project_root = Path(__file__).resolve().parent.parent
+    project_root = Path(__file__).resolve().parent
     output_folder = project_root / "output"
     output_folder.mkdir(exist_ok=True)
 

--- a/mellisa/mellisa.py
+++ b/mellisa/mellisa.py
@@ -2,6 +2,7 @@ import ascii
 from scrapy.utils.project import get_project_settings
 from misc.misc_prompts import Misc
 from spiders.m_spider import ScrapeParameters
+from pathlib import Path
 from scrapy.crawler import CrawlerProcess
 import ascii.description_ascii
 import argparse
@@ -23,11 +24,14 @@ def run_spider(output_file=None, **kwargs):
     settings = get_project_settings()
     spider_name = "param_spider"
 
-    output_folder = os.path.join(
-        os.path.expanduser("~"), "Mellisa_src/mellisa/output")
-    os.makedirs(output_folder, exist_ok=True)
-    output_path = os.path.join(output_folder, output_file)
+    # directory where mellisa.py is located
+    project_root = Path(__file__).resolve().parent.parent
+    output_folder = project_root / "output"
+    output_folder.mkdir(exist_ok=True)
 
+    # full path to the output file
+    output_path = output_folder / output_file if output_file else None
+    
     if output_file:
         settings.update({
             'FEED_FORMAT': 'json',
@@ -38,7 +42,6 @@ def run_spider(output_file=None, **kwargs):
     process = CrawlerProcess(settings)
     process.crawl(spider_name, **kwargs)
     process.start()
-
 
 def remove_char(domain):
     charsRemove = ["https://", "http://", "www."]

--- a/mellisa/spiders/m_spider.py
+++ b/mellisa/spiders/m_spider.py
@@ -18,10 +18,13 @@ class ScrapeParameters(scrapy.Spider):
             self.start_urls = [f"{url}"]
         elif start_urls:
             self.start_urls = start_urls
-
+    # ignore comments ("#") and empty lines ("//") in wordlist.txt
     def load_xpath(self, file_path):
         with open(file_path, "r") as f:
-            return [line.strip() for line in f if line.strip()]
+            return [line.strip()
+                    for line in f
+                    if line.strip() and not line.lstrip().startswith("#") and not line.lstrip().startswith("//")
+            ]
 
     # Return Num Callback
 

--- a/mellisa/wordlist.txt
+++ b/mellisa/wordlist.txt
@@ -1,17 +1,60 @@
-//link[contains(@href, "?")]/@href
+########################################################################
+#  Mellisa XPath Wordlist                                              #
+#  Original Author : yel1337                                           #
+#  Contributor     : JWhiteUX                                         #
+#                                                                    ##
+#  Add new XPaths below; keep one entry per line. Duplicate entries   #
+#  can be removed with: `sort -u wordlist.txt -o wordlist.txt`        #
+########################################################################
+
+##########  Links (a / link elements)  ################################
 /html//link[contains(@href, "?")]/@href
-//a[contains(@href, "?")]/@href
+/html//a[contains(@href, "?")]/@href
 //link[contains(@href, "?")]/@href
+//a[contains(@href, "?")]/@href
+//area[contains(@href, "?")]/@href
+//base[contains(@href, "?")]/@href
+
+##########  Scripts & Static Assets  ##################################
+/html//script[contains(@src, "?")]/@src
+//script[contains(@src, "?")]/@src
 //script[contains(@src, '?=')]/@src
 //source[contains(@src, '?=')]/@src
 //embed[contains(@src, '?=')]/@src
-//area[contains(@href, '?=')]/@href
-//base[contains(@href, '?=')]/@href
 //frame[contains(@src, '?=')]/@src
-//input[contains(@src, '?=')]/@src
-//audio[contains(@src, '?=')]/@src
-//video[contains(@src, '?=')]/@src
-//track[contains(@src, '?=')]/@src
-//applet[contains(@code, '?=')]/@code
-//button[contains(@formaction, '?=')]/@formaction
-//command[contains(@icon, '?=')]/@icon
+//iframe[contains(@src, "?")]/@src
+//object[contains(@data, "?")]/@data
+//object[contains(@code, '?=')]/@code
+
+##########  Media (img, audio, video, track)  #########################
+/html//img[contains(@src, "?")]/@src
+//img[contains(@src, "?")]/@src
+//audio[contains(@src, '?')]/@src
+//video[contains(@src, '?')]/@src
+//track[contains(@src, '?')]/@src
+//picture/source[contains(@srcset, '?')]/@srcset
+//img[contains(@data-src, '?')]/@data-src
+//img[contains(@data-srcset, '?')]/@data-srcset
+//img[contains(@data-href, '?')]/@data-href
+
+##########  Stylesheets & Inline CSS URLs  ############################
+/html//link[@rel='stylesheet' and contains(@href,'?')]/@href
+//style[contains(., '?')]/text()
+/html//@style[contains(., '?')]
+
+##########  Forms & Buttons  ##########################################
+/html//form[contains(@action, '?')]/@action
+//form[contains(@data-action, '?')]/@data-action
+//button[contains(@formaction, '?')]/@formaction
+//input[contains(@formaction, '?')]/@formaction
+//input[contains(@src, '?')]/@src
+
+##########  Data-Attributes (common in SPAs)  ##########################
+/html//*[@data-url and contains(@data-url,'?')]/@data-url
+/html//*[@data-href and contains(@data-href,'?')]/@data-href
+/html//*[@data-src and contains(@data-src,'?')]/@data-src
+/html//*[@data-endpoint and contains(@data-endpoint,'?')]/@data-endpoint
+
+##########  SVG & Font Assets  ########################################
+/html//svg//*[contains(@xlink:href,'?')]/@xlink:href
+/html//link[@rel='preload' and contains(@href,'?')]/@href


### PR DESCRIPTION
### Pull-Request Summary
* Ignore comments in wordlist.txt loader
* `load_xpath()` now skips lines that start with #, preventing XPath-error crashes.
* Expanded wordlist.txt
* Removed duplicate entry, normalized ?= ➜ ?, added broader XPath patterns (forms, images, iframes, data-attrs).
* Prefaced file with an attribution banner — Feels dorky, might remove
* Added “Quick Functional Test” section to README.md
* Walk-through for spinning up NetSPI’s Path Injection Weakness lab, running Mellisa against http://localhost:8888/, and reviewing the JSON results.
* Redirected crawler output to local project folder
* `run_spider()` now resolves `output/` relative to `mellisa.py` (`<repo>/mellisa/output/…`) instead of `$HOME/Mellisa_src/….`
* Result files are named `<host>_<port>.json  | <targetdomain>_<directory>.json` (e.g., output/localhost_8888.json).